### PR TITLE
Create initial usecases and Gateways & project form

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -378,6 +378,12 @@
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
       "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
+    "assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true
+    },
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
@@ -1724,6 +1730,20 @@
         "lazy-cache": "^1.0.3"
       }
     },
+    "chai": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.1.2.tgz",
+      "integrity": "sha1-D2RYS6ZC8PKs4oBiefTwbKI61zw=",
+      "dev": true,
+      "requires": {
+        "assertion-error": "^1.0.1",
+        "check-error": "^1.0.1",
+        "deep-eql": "^3.0.0",
+        "get-func-name": "^2.0.0",
+        "pathval": "^1.0.0",
+        "type-detect": "^4.0.0"
+      }
+    },
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
@@ -1752,6 +1772,12 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I="
+    },
+    "check-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+      "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+      "dev": true
     },
     "chokidar": {
       "version": "2.0.4",
@@ -2514,6 +2540,15 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
+    },
+    "deep-eql": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
+      "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "^4.0.0"
+      }
     },
     "deep-equal": {
       "version": "1.0.1",
@@ -4372,6 +4407,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
       "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
+    },
+    "get-func-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+      "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -6837,6 +6878,34 @@
         "lower-case": "^1.1.1"
       }
     },
+    "nock": {
+      "version": "9.4.3",
+      "resolved": "https://registry.npmjs.org/nock/-/nock-9.4.3.tgz",
+      "integrity": "sha512-inJFXR3REBvHbZy6nVVwaoKbVTR8Y4Ag051Y/pd2pNPy7HDYtQkenfilBwxToNsW9p1RTeBUml4SPK/mWrFihA==",
+      "dev": true,
+      "requires": {
+        "chai": "^4.1.2",
+        "debug": "^3.1.0",
+        "deep-equal": "^1.0.0",
+        "json-stringify-safe": "^5.0.1",
+        "lodash": "^4.17.5",
+        "mkdirp": "^0.5.0",
+        "propagate": "^1.0.0",
+        "qs": "^6.5.1",
+        "semver": "^5.5.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
+    },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
@@ -7310,6 +7379,12 @@
         "pify": "^2.0.0",
         "pinkie-promise": "^2.0.0"
       }
+    },
+    "pathval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+      "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.16",
@@ -8599,6 +8674,12 @@
         "loose-envify": "^1.3.1",
         "object-assign": "^4.1.1"
       }
+    },
+    "propagate": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/propagate/-/propagate-1.0.0.tgz",
+      "integrity": "sha1-AMLa7t2iDofjeCs0Stuhzd1q1wk=",
+      "dev": true
     },
     "proxy-addr": {
       "version": "2.0.3",
@@ -10310,6 +10391,12 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",

--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
+  },
+  "devDependencies": {
+    "nock": "^9.4.3"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import FormField from './components/FormField';
-import ReviewForm from './components/ReviewForm';
+import ProjectForm from './components/ProjectForm';
 import GetProject from './UseCase/GetProject';
 import ProjectGateway from './Gateway/ProjectGateway';
 
@@ -11,7 +11,7 @@ const App = () => (
   <Router>
     <div>
       <Route exact path="/" component={Home} />
-      <Route path="/review/:id" component={Review} />
+      <Route path="/review/:id" component={Project} />
     </div>
   </Router>
 );
@@ -24,14 +24,36 @@ const Home = () => (
 
 const getProjectUsecase = new GetProject(new ProjectGateway());
 
-class Review extends React.Component {
+class Project extends React.Component {
   constructor() {
     super();
     this.state = {loading: true};
   }
 
   presentProject = async projectData => {
-    await this.setState({loading: false, reviewData: projectData});
+    const summary = projectData.data.summary;
+    const infrastructure = projectData.data.infrastructure;
+    const financial = projectData.data.financial;
+
+    const formData = {
+      summary: {
+        name: summary.projectName,
+        description: summary.description,
+        status: summary.status,
+        leadAuthority: summary.leadAuthority,
+      },
+      infrastructure: {
+        infraType: infrastructure.type,
+        description: infrastructure.description,
+        completionDate: infrastructure.completionDate,
+      },
+      financial: {
+        dateReceived: financial.date,
+        fundedThroughHIF: financial.fundedThroughHIF,
+      },
+    };
+
+    await this.setState({loading: false, formData: formData});
   };
 
   fetchData = () => {
@@ -48,9 +70,9 @@ class Review extends React.Component {
     }
 
     return (
-      <ReviewForm
+      <ProjectForm
         reviewId={this.props.match.params.id}
-        data={this.state.reviewData.data}
+        data={this.state.formData}
       />
     );
   }

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import FormField from './components/FormField';
 import ReviewForm from './components/ReviewForm';
+import GetProject from './UseCase/GetProject';
+import ProjectGateway from './Gateway/ProjectGateway';
 
 import './App.css';
 import {BrowserRouter as Router, Route} from 'react-router-dom';
@@ -20,20 +22,20 @@ const Home = () => (
   </div>
 );
 
+const getProjectUsecase = new GetProject(new ProjectGateway());
+
 class Review extends React.Component {
   constructor() {
     super();
     this.state = {loading: true};
   }
 
-  fetchData = async () => {
-    let raw_review = await fetch(
-      `${process.env.REACT_APP_HIF_API_URL}project/find?id=${
-        this.props.match.params.id
-      }`,
-    );
-    let json_review = await raw_review.json();
-    await this.setState({loading: false, reviewData: json_review});
+  presentProject = async projectData => {
+    await this.setState({loading: false, reviewData: projectData});
+  };
+
+  fetchData = () => {
+    getProjectUsecase.execute(this, { id: this.props.match.params.id })
   };
 
   async componentDidMount() {
@@ -56,11 +58,9 @@ class Review extends React.Component {
   render() {
     return (
       <div className="container-fluid">
-        <div className="col-md-10 col-md-offset-1">
-          {this.renderForm()}
-        </div>
+        <div className="col-md-10 col-md-offset-1">{this.renderForm()}</div>
       </div>
-    )
+    );
   }
 }
 

--- a/src/Gateway/ProjectGateway/index.js
+++ b/src/Gateway/ProjectGateway/index.js
@@ -1,0 +1,18 @@
+import fetch from 'isomorphic-fetch'
+
+export default class ProjectGateway {
+  async findById(id) {
+    let rawResponse = await fetch(
+      `${process.env.REACT_APP_HIF_API_URL}project/find?id=${id}`,
+      {
+        headers: {'Content-Type': 'application/json'},
+      },
+    );
+    if (rawResponse.ok) {
+      let foundProject = await rawResponse.json();
+      return {success: true, foundProject};
+    } else {
+      return {success: false};
+    }
+  }
+}

--- a/src/Gateway/ProjectGateway/projectGateway.test.js
+++ b/src/Gateway/ProjectGateway/projectGateway.test.js
@@ -1,0 +1,63 @@
+import nock from 'nock';
+import ProjectGateway from '.';
+
+describe('Project Gateway', () => {
+  describe('Given a Project is found', () => {
+    let projectRequest, response;
+
+    describe('Example one', () => {
+      beforeEach(async () => {
+        process.env.REACT_APP_HIF_API_URL = 'http://cat.meow/';
+        projectRequest = nock('http://cat.meow')
+          .matchHeader('Content-Type', 'application/json')
+          .get('/project/find?id=1')
+          .reply(200, {some: 'data'});
+        let gateway = new ProjectGateway();
+        response = await gateway.findById(1);
+      });
+
+      it('Fetches the project from the API', () => {
+        expect(projectRequest.isDone()).toBeTruthy();
+      });
+
+      it('Projects the response from the api', () => {
+        expect(response).toEqual({success: true, foundProject: {some: 'data'}});
+      });
+    });
+
+    describe('Example two', () => {
+      beforeEach(async () => {
+        process.env.REACT_APP_HIF_API_URL = 'http://dog.woof/';
+        let projectRequest = nock('http://dog.woof')
+          .matchHeader('Content-Type', 'application/json')
+          .get('/project/find?id=5')
+          .reply(200, {other: 'things'});
+        let gateway = new ProjectGateway();
+        response = await gateway.findById(5);
+      });
+
+      it('Fetches the project from the API', () => {
+        expect(projectRequest.isDone()).toBeTruthy();
+      });
+
+      it('Projects the response from the api', () => {
+        expect(response).toEqual({success: true, foundProject: {other: 'things'}});
+      });
+    });
+  });
+
+  describe('Given a project is not found', () => {
+    it('Projects unsuccessful', async () => {
+      process.env.REACT_APP_HIF_API_URL = 'http://dog.woof/';
+      let projectRequest = nock('http://dog.woof')
+        .matchHeader('Content-Type', 'application/json')
+        .get('/project/find?id=5')
+        .reply(404);
+      let gateway = new ProjectGateway();
+      let response = await gateway.findById(5)
+      expect(response).toEqual({ success: false })
+    });
+  });
+});
+
+

--- a/src/Gateway/ReturnGateway/index.js
+++ b/src/Gateway/ReturnGateway/index.js
@@ -1,0 +1,18 @@
+import fetch from 'isomorphic-fetch';
+
+export default class ReturnGateway {
+  async findById(id) {
+    let rawResponse = await fetch(
+      `${process.env.REACT_APP_HIF_API_URL}return/${id}`,
+      {
+        headers: {'Content-Type': 'application/json'},
+      },
+    );
+    if (rawResponse.ok) {
+      let foundReturn = await rawResponse.json();
+      return {success: true, foundReturn};
+    } else {
+      return {success: false};
+    }
+  }
+}

--- a/src/Gateway/ReturnGateway/returnGateway.test.js
+++ b/src/Gateway/ReturnGateway/returnGateway.test.js
@@ -1,0 +1,64 @@
+import nock from 'nock';
+import ReturnGateway from '.';
+
+describe('Return Gateway', () => {
+  describe('Given a Return is found', () => {
+    let returnRequest, response;
+
+    describe('Example one', () => {
+      beforeEach(async () => {
+        process.env.REACT_APP_HIF_API_URL = 'http://cat.meow/';
+        returnRequest = nock('http://cat.meow')
+          .matchHeader('Content-Type', 'application/json')
+          .get('/return/1')
+          .reply(200, {some: 'data'});
+        let gateway = new ReturnGateway();
+        response = await gateway.findById(1);
+      });
+
+      it('Fetches the return from the API', () => {
+        expect(returnRequest.isDone()).toBeTruthy();
+      });
+
+      it('Returns the response from the api', () => {
+        expect(response).toEqual({success: true, foundReturn: {some: 'data'}});
+      });
+    });
+
+    describe('Example two', () => {
+      beforeEach(async () => {
+        process.env.REACT_APP_HIF_API_URL = 'http://dog.woof/';
+        let returnRequest = nock('http://dog.woof')
+          .matchHeader('Content-Type', 'application/json')
+          .get('/return/5')
+          .reply(200, {other: 'things'});
+        let gateway = new ReturnGateway();
+        response = await gateway.findById(5);
+      });
+
+      it('Fetches the return from the API', () => {
+        expect(returnRequest.isDone()).toBeTruthy();
+      });
+
+      it('Returns the response from the api', () => {
+        expect(response).toEqual({
+          success: true,
+          foundReturn: {other: 'things'},
+        });
+      });
+    });
+  });
+
+  describe('Given a return is not found', () => {
+    it('Returns unsuccessful', async () => {
+      process.env.REACT_APP_HIF_API_URL = 'http://dog.woof/';
+      let returnRequest = nock('http://dog.woof')
+        .matchHeader('Content-Type', 'application/json')
+        .get('/return/5')
+        .reply(404);
+      let gateway = new ReturnGateway();
+      let response = await gateway.findById(5);
+      expect(response).toEqual({success: false});
+    });
+  });
+});

--- a/src/UseCase/GetProject/getProject.test.js
+++ b/src/UseCase/GetProject/getProject.test.js
@@ -29,15 +29,15 @@ describe('GetProject', () => {
         useCase = getUseCase(foundProject);
       });
 
-      it('Calls the gateway with the correct ID', () => {
+      it('Calls the gateway with the correct ID', async () => {
         let presenterSpy = {presentProject: jest.fn()};
-        useCase.execute(presenterSpy, {id: 1});
+        await useCase.execute(presenterSpy, {id: 1});
         expect(projectGatewaySpy.findById).toBeCalledWith(1);
       });
 
-      it('Presents the project', () => {
+      it('Presents the project', async () => {
         let presenterSpy = {presentProject: jest.fn()};
-        useCase.execute(presenterSpy, {id: 1});
+        await useCase.execute(presenterSpy, {id: 1});
         expect(presenterSpy.presentProject).toBeCalledWith(foundProject);
       });
     });
@@ -56,28 +56,28 @@ describe('GetProject', () => {
         useCase = getUseCase(foundProject);
       });
 
-      it('Calls the gateway with the correct ID', () => {
+      it('Calls the gateway with the correct ID', async () => {
         let presenterSpy = {presentProject: jest.fn()};
-        useCase.execute(presenterSpy, {id: 5});
+        await useCase.execute(presenterSpy, {id: 5});
         expect(projectGatewaySpy.findById).toBeCalledWith(5);
       });
 
-      it('Presents the project', () => {
+      it('Presents the project', async () => {
         let presenterSpy = {presentProject: jest.fn()};
-        useCase.execute(presenterSpy, {id: 5});
+        await useCase.execute(presenterSpy, {id: 5});
         expect(presenterSpy.presentProject).toBeCalledWith(foundProject);
       });
     });
   });
 
   describe('Given a project is not found', () => {
-    it('Presents the project not found', () => {
+    it('Presents the project not found', async () => {
       let projectGatewaySpy = {
         findById: jest.fn(() => ({success: false})),
       };
       let useCase = new GetProject(projectGatewaySpy);
       let presenterSpy = {presentProjectNotFound: jest.fn()};
-      useCase.execute(presenterSpy, {id: 5});
+      await useCase.execute(presenterSpy, {id: 5});
       expect(presenterSpy.presentProjectNotFound).toBeCalled();
     });
   });

--- a/src/UseCase/GetProject/getProject.test.js
+++ b/src/UseCase/GetProject/getProject.test.js
@@ -1,0 +1,86 @@
+import GetProject from '.';
+
+describe('GetProject', () => {
+  let projectGatewaySpy;
+
+  function getUseCase(foundProject) {
+    projectGatewaySpy = {
+      findById: jest.fn(() => ({
+        success: true,
+        foundProject,
+      })),
+    };
+
+    return new GetProject(projectGatewaySpy);
+  }
+
+  describe('Given a project is successfully found', () => {
+    describe('Example one', () => {
+      let foundProject, useCase;
+
+      beforeEach(() => {
+        foundProject = {
+          type: 'hif',
+          data: {
+            cat: 'meow',
+          },
+        };
+
+        useCase = getUseCase(foundProject);
+      });
+
+      it('Calls the gateway with the correct ID', () => {
+        let presenterSpy = {presentProject: jest.fn()};
+        useCase.execute(presenterSpy, {id: 1});
+        expect(projectGatewaySpy.findById).toBeCalledWith(1);
+      });
+
+      it('Presents the project', () => {
+        let presenterSpy = {presentProject: jest.fn()};
+        useCase.execute(presenterSpy, {id: 1});
+        expect(presenterSpy.presentProject).toBeCalledWith(foundProject);
+      });
+    });
+
+    describe('Example two', () => {
+      let foundProject, useCase;
+
+      beforeEach(() => {
+        foundProject = {
+          type: 'abc',
+          data: {
+            dog: 'woof',
+          },
+        };
+
+        useCase = getUseCase(foundProject);
+      });
+
+      it('Calls the gateway with the correct ID', () => {
+        let presenterSpy = {presentProject: jest.fn()};
+        useCase.execute(presenterSpy, {id: 5});
+        expect(projectGatewaySpy.findById).toBeCalledWith(5);
+      });
+
+      it('Presents the project', () => {
+        let presenterSpy = {presentProject: jest.fn()};
+        useCase.execute(presenterSpy, {id: 5});
+        expect(presenterSpy.presentProject).toBeCalledWith(foundProject);
+      });
+    });
+  });
+
+  describe('Given a project is not found', () => {
+    it('Presents the project not found', () => {
+      let projectGatewaySpy = {
+        findById: jest.fn(() => ({success: false})),
+      };
+      let useCase = new GetProject(projectGatewaySpy);
+      let presenterSpy = {presentProjectNotFound: jest.fn()};
+      useCase.execute(presenterSpy, {id: 5});
+      expect(presenterSpy.presentProjectNotFound).toBeCalled();
+    });
+  });
+});
+
+

--- a/src/UseCase/GetProject/index.js
+++ b/src/UseCase/GetProject/index.js
@@ -3,8 +3,8 @@ export default class GetProject {
     this.projectGateway = projectGateway
   }
 
-  execute(presenter, request) {
-    let {success, foundProject} = this.projectGateway.findById(request.id)
+  async execute(presenter, request) {
+    let {success, foundProject} = await this.projectGateway.findById(request.id)
     if(success) {
       presenter.presentProject(foundProject)
     } else {

--- a/src/UseCase/GetProject/index.js
+++ b/src/UseCase/GetProject/index.js
@@ -1,0 +1,15 @@
+export default class GetProject {
+  constructor(projectGateway) {
+    this.projectGateway = projectGateway
+  }
+
+  execute(presenter, request) {
+    let {success, foundProject} = this.projectGateway.findById(request.id)
+    if(success) {
+      presenter.presentProject(foundProject)
+    } else {
+      presenter.presentProjectNotFound()
+    }
+  }
+}
+

--- a/src/UseCase/GetReturn/GetReturn.test.js
+++ b/src/UseCase/GetReturn/GetReturn.test.js
@@ -1,0 +1,83 @@
+import GetReturn from '.';
+
+describe('GetReturn', () => {
+  let returnGatewaySpy;
+
+  function getUseCase(foundReturn) {
+    returnGatewaySpy = {
+      findById: jest.fn(() => ({
+        success: true,
+        foundReturn,
+      })),
+    };
+    return new GetReturn(returnGatewaySpy);
+  }
+
+  describe('Given a return is successfully found', () => {
+    describe('Example one', () => {
+      let foundReturn, useCase;
+
+      beforeEach(() => {
+        foundReturn = {
+          type: 'hif',
+          data: {
+            cat: 'meow',
+          },
+        };
+
+        useCase = getUseCase(foundReturn);
+      });
+
+      it('Calls the gateway with the correct ID', () => {
+        let presenterSpy = {presentReturn: jest.fn()};
+        useCase.execute(presenterSpy, {id: 1});
+        expect(returnGatewaySpy.findById).toBeCalledWith(1);
+      });
+
+      it('Presents the return', () => {
+        let presenterSpy = {presentReturn: jest.fn()};
+        useCase.execute(presenterSpy, {id: 1});
+        expect(presenterSpy.presentReturn).toBeCalledWith(foundReturn);
+      });
+    });
+
+    describe('Example two', () => {
+      let foundReturn, useCase;
+
+      beforeEach(() => {
+        foundReturn = {
+          type: 'abc',
+          data: {
+            dog: 'woof',
+          },
+        };
+
+        useCase = getUseCase(foundReturn);
+      });
+
+      it('Calls the gateway with the correct ID', () => {
+        let presenterSpy = {presentReturn: jest.fn()};
+        useCase.execute(presenterSpy, {id: 5});
+        expect(returnGatewaySpy.findById).toBeCalledWith(5);
+      });
+
+      it('Presents the return', () => {
+        let presenterSpy = {presentReturn: jest.fn()};
+        useCase.execute(presenterSpy, {id: 5});
+        expect(presenterSpy.presentReturn).toBeCalledWith(foundReturn);
+      });
+    });
+  });
+
+  describe('Given a return is not found', () => {
+    it('Presents the return not found', () => {
+      let returnGatewaySpy = {
+        findById: jest.fn(() => ({success: false})),
+      };
+      let useCase = new GetReturn(returnGatewaySpy);
+      let presenterSpy = {presentReturnNotFound: jest.fn()};
+      useCase.execute(presenterSpy, {id: 5});
+      expect(presenterSpy.presentReturnNotFound).toBeCalled();
+    });
+  });
+});

--- a/src/UseCase/GetReturn/index.js
+++ b/src/UseCase/GetReturn/index.js
@@ -1,0 +1,14 @@
+export default class GetReturn {
+  constructor(returnGateway) {
+    this.returnGateway = returnGateway;
+  }
+
+  execute(presenter, request) {
+    let {success, foundReturn} = this.returnGateway.findById(request.id);
+    if (success) {
+      presenter.presentReturn(foundReturn);
+    } else {
+      presenter.presentReturnNotFound();
+    }
+  }
+}

--- a/src/components/ProjectForm/index.js
+++ b/src/components/ProjectForm/index.js
@@ -12,8 +12,6 @@ export default class ProjectForm extends React.Component {
             description: formData.summary.description,
             projectName: formData.summary.name,
             leadAuthority: formData.summary.leadAuthority,
-            status: formData.summary.status,
-            statusCommentary: formData.summary.comments,
           },
           infrastructure: {
             completionDate: formData.infrastructure.completionDate,
@@ -43,6 +41,7 @@ export default class ProjectForm extends React.Component {
       alert('Review submission unsuccessful');
     }
   };
+
   render() {
     const schema = {
       title: 'HIF Review',
@@ -54,16 +53,7 @@ export default class ProjectForm extends React.Component {
           properties: {
             name: {type: 'string', title: 'Name'},
             description: {type: 'string', title: 'Description'},
-            leadAuthority: {type: 'string', title: 'Lead Authority'},
-            status: {
-              type: 'string',
-              title: 'Status',
-              enum: ['Completed', 'On Schedule', 'Delayed'],
-            },
-            comments: {
-              type: 'string',
-              title: 'Comments',
-            },
+            leadAuthority: {type: 'string', title: 'Lead Authority'}
           },
         },
         infrastructure: {
@@ -94,12 +84,27 @@ export default class ProjectForm extends React.Component {
       },
     };
 
+    const uiSchema = {
+      summary: {
+        name: {'ui:readonly': true},
+        description: {'ui:readonly': true},
+        leadAuthority: {'ui:readonly': true},
+      },
+      infrastructure: {
+        infraType: {'ui:readonly': true},
+        description: {'ui:readonly': true},
+        completionDate: {'ui:readonly': true},
+      },
+      financial: {
+        dateReceived: {'ui:readonly': true},
+        fundedThroughHIF: {'ui:readonly': true}
+      }
+    };
+
     return (
-      <Form
-        schema={schema}
-        formData={this.props.data}
-        onSubmit={({formData}) => this.submitFormData(formData)}
-      />
+      <Form schema={schema} uiSchema={uiSchema} formData={this.props.data}>
+        <div />
+      </Form>
     );
   }
 }

--- a/src/components/ProjectForm/index.js
+++ b/src/components/ProjectForm/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import Form from 'react-jsonschema-form';
 
-export default class ReviewForm extends React.Component {
+export default class ProjectForm extends React.Component {
   submitFormData = async formData => {
     let reviewData = {
       id: this.props.reviewId,
@@ -94,32 +94,10 @@ export default class ReviewForm extends React.Component {
       },
     };
 
-    const summary = this.props.data.summary;
-    const infrastructure = this.props.data.infrastructure;
-    const financial = this.props.data.financial;
-
-    const formData = {
-      summary: {
-        name: summary.projectName,
-        description: summary.description,
-        status: summary.status,
-        leadAuthority: summary.leadAuthority,
-      },
-      infrastructure: {
-        infraType: infrastructure.type,
-        description: infrastructure.description,
-        completionDate: infrastructure.completionDate,
-      },
-      financial: {
-        dateReceived: financial.date,
-        fundedThroughHIF: financial.fundedThroughHIF,
-      },
-    };
-
     return (
       <Form
         schema={schema}
-        formData={formData}
+        formData={this.props.data}
         onSubmit={({formData}) => this.submitFormData(formData)}
       />
     );


### PR DESCRIPTION
Why 
- We need to start using production code not spike code, this starts to replace some of the spike code with CA Usecases/Gateways
- We need to have an initial view of the baseline data of a project before starting a return

What
- Adds use cases/gateways for getting and presenting projects/returns
- Moves the `reviewForm` to a `projectForm` which is a readonly view of the project's baseline data

![image](https://user-images.githubusercontent.com/976254/43259126-1b15a4ba-90cd-11e8-9a0c-ac6e13eade9d.png)
