### PR TITLE
Move page objects to components

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,22 +1,60 @@
 import React from 'react';
 import ProjectForm from './Components/ProjectForm';
-import ReturnForm from './Components/ReturnForm';
+import ProjectPage from './Components/ProjectPage';
+import ReturnPage from './Components/ReturnPage';
 import GetProject from './UseCase/GetProject';
-import GetReturn from './UseCase/GetReturn'
-import CreateReturn from './UseCase/CreateReturn'
+import GetReturn from './UseCase/GetReturn';
+import CreateReturn from './UseCase/CreateReturn';
 import ProjectGateway from './Gateway/ProjectGateway';
-import ReturnGateway from './Gateway/ReturnGateway'
+import ReturnGateway from './Gateway/ReturnGateway';
 
 import './App.css';
 import {BrowserRouter as Router, Route} from 'react-router-dom';
 
+const getProjectUsecase = new GetProject(new ProjectGateway());
+const getReturnUsecase = new GetReturn(new ReturnGateway());
+const createReturn = new CreateReturn(new ReturnGateway());
+
 const App = () => (
   <Router>
-    <div className='monitor-container'>
+    <div className="monitor-container">
       <Route exact path="/" component={Home} />
-      <Route exact path="/project/:id" component={Project} />
-      <Route exact path="/project/:projectId/return" component={Return} />
-      <Route exact path="/project/:projectId/return/:returnId" component={Return} />
+      <Route
+        exact
+        path="/project/:id"
+        render={props => (
+          <ProjectPage
+            {...props}
+            getProject={getProjectUsecase}
+            getReturn={getReturnUsecase}
+            createReturn={createReturn}
+          />
+        )}
+      />
+      <Route
+        exact
+        path="/project/:projectId/return"
+        render={props => (
+          <ReturnPage
+            {...props}
+            getProject={getProjectUsecase}
+            getReturn={getReturnUsecase}
+            createReturn={createReturn}
+          />
+        )}
+      />
+      <Route
+        exact
+        path="/project/:projectId/return/:returnId"
+        render={props => (
+          <ReturnPage
+            {...props}
+            getProject={getProjectUsecase}
+            getReturn={getReturnUsecase}
+            createReturn={createReturn}
+          />
+        )}
+      />
     </div>
   </Router>
 );
@@ -26,130 +64,5 @@ const Home = () => (
     <h2>Home</h2>
   </div>
 );
-
-const getProjectUsecase = new GetProject(new ProjectGateway());
-const getReturnUsecase = new GetReturn(new ReturnGateway());
-const createReturn = new CreateReturn(new ReturnGateway());
-
-//Presenters
-class Return extends React.Component {
-
-  constructor() {
-    super();
-    this.state = {loading: true};
-  }
-
-  submissionSuccessful = returnId => {
-    this.props.history.push(`return/${returnId}`);
-  }
-
-  onFormSubmit = async formData => {
-    createReturn.execute(this, {projectId: this.props.match.params.projectId, data: formData})
-  }
-
-  presentReturn = async returnData => {
-    await this.setState({loading: false, formData: returnData.data, formSchema: returnData.schema});
-  };
-
-  presentProject = async projectData => {
-    await this.setState({loading: false, formData: projectData.data, formSchema: projectData.schema});
-  };
-
-  fetchData = () => {
-    if(this.props.match.params.returnId) {
-      getReturnUsecase.execute(this, {id: this.props.match.params.returnId})
-    } else {
-      getProjectUsecase.execute(this, {id: this.props.match.params.projectId});
-    }
-  };
-
-  isReadOnly = () => {
-    return !(this.props.match.params.returnId === undefined)
-  }
-
-  async componentDidMount() {
-    await this.fetchData();
-  }
-
-  renderForm() {
-    if (this.state.loading) {
-      return <div />;
-    }
-
-    return (
-      <ReturnForm
-        onSubmit={this.onFormSubmit}
-        data={this.state.formData}
-        schema={this.state.formSchema}
-        readOnly={this.isReadOnly()}
-      />
-    );
-  }
-
-  backToProject = (e) => {
-    this.props.history.push(`/project/${this.props.match.params.projectId}`)
-    e.preventDefault()
-  }
-
-  render() {
-    return (
-      <div className="container-fluid">
-        <div className="col-md-2 back-to-project">
-          <button className="btn btn-link btn-lg btn-block" onClick={this.backToProject}>Back to project overview</button>
-        </div>
-        <div className="col-md-10 col-md-offset-1">{this.renderForm()}</div>
-      </div>
-    );
-  }
-}
-
-class Project extends React.Component {
-  constructor() {
-    super();
-    this.state = {loading: true};
-  }
-
-  presentProject = async projectData => {
-    await this.setState({loading: false, formData: projectData.data, formSchema: projectData.schema });
-  };
-
-  fetchData = async () => {
-    await getProjectUsecase.execute(this, {id: this.props.match.params.id});
-  };
-
-  async componentDidMount() {
-    await this.fetchData();
-  }
-
-  createReturn = (e) => {
-    this.props.history.push(`/project/${this.props.match.params.id}/return`);
-    e.preventDefault()
-  }
-
-  renderForm() {
-    if (this.state.loading) {
-      return <div />;
-    }
-
-    return (
-      <div>
-        <ProjectForm
-          reviewId={this.props.match.params.id}
-          data={this.state.formData}
-          schema={this.state.formSchema}
-        />
-        <button className="btn btn-primary" onClick={this.createReturn}>Create a new return</button>
-      </div>
-    );
-  }
-
-  render() {
-    return (
-      <div className="container-fluid">
-        <div className="col-md-10 col-md-offset-1">{this.renderForm()}</div>
-      </div>
-    );
-  }
-}
 
 export default App;

--- a/src/Components/ProjectPage/index.js
+++ b/src/Components/ProjectPage/index.js
@@ -1,0 +1,58 @@
+import React from 'react'
+import ProjectForm from '../ProjectForm'
+
+export default class Project extends React.Component {
+  constructor() {
+    super();
+    this.state = {loading: true};
+  }
+
+  presentProject = async projectData => {
+    await this.setState({
+      loading: false,
+      formData: projectData.data,
+      formSchema: projectData.schema,
+    });
+  };
+
+  fetchData = async () => {
+    await this.props.getProject.execute(this, {id: this.props.match.params.id});
+  };
+
+  async componentDidMount() {
+    await this.fetchData();
+  }
+
+  createReturn = e => {
+    this.props.history.push(`/project/${this.props.match.params.id}/return`);
+    e.preventDefault();
+  };
+
+  renderForm() {
+    if (this.state.loading) {
+      return <div />;
+    }
+
+    return (
+      <div>
+        <ProjectForm
+          reviewId={this.props.match.params.id}
+          data={this.state.formData}
+          schema={this.state.formSchema}
+        />
+        <button className="btn btn-primary" onClick={this.createReturn}>
+          Create a new return
+        </button>
+      </div>
+    );
+  }
+
+  render() {
+    return (
+      <div className="container-fluid">
+        <div className="col-md-10 col-md-offset-1">{this.renderForm()}</div>
+      </div>
+    );
+  }
+}
+

--- a/src/Components/ReturnPage/index.js
+++ b/src/Components/ReturnPage/index.js
@@ -1,0 +1,91 @@
+import React from 'react';
+import ReturnForm from '../ReturnForm';
+
+export default class ReturnPage extends React.Component {
+  constructor() {
+    super();
+    this.state = {loading: true};
+  }
+
+  submissionSuccessful = returnId => {
+    this.props.history.push(`return/${returnId}`);
+  };
+
+  onFormSubmit = async formData => {
+    this.props.createReturn.execute(this, {
+      projectId: this.props.match.params.projectId,
+      data: formData,
+    });
+  };
+
+  presentReturn = async returnData => {
+    await this.setState({
+      loading: false,
+      formData: returnData.data,
+      formSchema: returnData.schema,
+    });
+  };
+
+  presentProject = async projectData => {
+    await this.setState({
+      loading: false,
+      formData: projectData.data,
+      formSchema: projectData.schema,
+    });
+  };
+
+  fetchData = () => {
+    if (this.props.match.params.returnId) {
+      this.props.getReturn.execute(this, {
+        id: this.props.match.params.returnId,
+      });
+    } else {
+      this.props.getProject.execute(this, {
+        id: this.props.match.params.projectId,
+      });
+    }
+  };
+
+  isReadOnly = () => {
+    return !(this.props.match.params.returnId === undefined);
+  };
+
+  async componentDidMount() {
+    await this.fetchData();
+  }
+
+  renderForm() {
+    if (this.state.loading) {
+      return <div />;
+    }
+
+    return (
+      <ReturnForm
+        onSubmit={this.onFormSubmit}
+        data={this.state.formData}
+        schema={this.state.formSchema}
+        readOnly={this.isReadOnly()}
+      />
+    );
+  }
+
+  backToProject = e => {
+    this.props.history.push(`/project/${this.props.match.params.projectId}`);
+    e.preventDefault();
+  };
+
+  render() {
+    return (
+      <div className="container-fluid">
+        <div className="col-md-2 back-to-project">
+          <button
+            className="btn btn-link btn-lg btn-block"
+            onClick={this.backToProject}>
+            Back to project overview
+          </button>
+        </div>
+        <div className="col-md-10 col-md-offset-1">{this.renderForm()}</div>
+      </div>
+    );
+  }
+}


### PR DESCRIPTION
What - Moved the page objects to components & inverted their dependencies

Why - components are hard to test in their current state, this refactor means we can begin testing them appropriately